### PR TITLE
Fix django path in flask wrapper

### DIFF
--- a/backend/flask_app.py
+++ b/backend/flask_app.py
@@ -2,8 +2,9 @@ from flask import Flask
 import os
 import sys
 
-# Add Django project to path
-sys.path.insert(0, '/home/ubuntu/ceres_backend')
+# Add Django project to path dynamically
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, BASE_DIR)
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ceres_project.settings')
 
 import django


### PR DESCRIPTION
## Summary
- fix path to Django project in `flask_app.py`

## Testing
- `python3 -m py_compile backend/flask_app.py`
- `python3 -m py_compile $(git ls-files '*.py')`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684d5fe4152c832084e94dc1961f3617