### PR TITLE
Add meta option to success_response

### DIFF
--- a/backend/ceres_project/utils.py
+++ b/backend/ceres_project/utils.py
@@ -5,15 +5,17 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.pagination import PageNumberPagination
 
-def success_response(data=None, message="Success", status_code=status.HTTP_200_OK):
+def success_response(data=None, message="Success", status_code=status.HTTP_200_OK, meta=None):
     """
     Standard success response format
     """
     response_data = {
         "success": True,
         "message": message,
-        "data": data
+        "data": data,
     }
+    if meta is not None:
+        response_data["meta"] = meta
     return Response(response_data, status=status_code)
 
 def error_response(message="Error", errors=None, status_code=status.HTTP_400_BAD_REQUEST):

--- a/backend/user_management/tests.py
+++ b/backend/user_management/tests.py
@@ -1,3 +1,25 @@
 from django.test import TestCase
+from rest_framework import status
 
-# Create your tests here.
+from ceres_project.utils import success_response
+
+
+class SuccessResponseTest(TestCase):
+    """Tests for the success_response utility function"""
+
+    def test_success_response_with_meta(self):
+        meta = {"page": 2}
+        response = success_response({"foo": "bar"}, meta=meta)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+        self.assertEqual(response.data["meta"], meta)
+        self.assertEqual(response.data["data"], {"foo": "bar"})
+
+    def test_success_response_without_meta(self):
+        response = success_response({"foo": "bar"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+        self.assertNotIn("meta", response.data)
+


### PR DESCRIPTION
## Summary
- extend `success_response` with optional `meta` argument
- test new behaviour in `user_management.tests`

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_684dc0f689108320994e0a827f26d31f