### PR TITLE
Fix missing static dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,6 +276,8 @@ logs
 media/
 uploads/
 static/
+!backend/static/
+!backend/static/.gitkeep
 
 # Backup files
 *.bak


### PR DESCRIPTION
## Summary
- add backend/static with gitkeep file
- unignore backend/static so Django can collect static files

## Testing
- `python manage.py test`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dc8a945188320847b8043f1c1aca1