### PR TITLE
Add Dockerfiles and nginx reverse proxy

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project
+COPY . .
+
+# Collect static files
+RUN python manage.py collectstatic --noinput
+
+CMD ["gunicorn", "ceres_project.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     volumes:
       - ./backend:/app
       - media_files:/app/media
-      - static_files:/app/static
+      - static_files:/app/staticfiles
     ports:
       - "8000:8000"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,18 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* pnpm-lock.yaml* ./
+# Install dependencies using pnpm if lockfile exists, else npm
+RUN if [ -f pnpm-lock.yaml ]; then \
+      corepack enable && pnpm install --frozen-lockfile; \
+    else \
+      npm ci; \
+    fi
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine AS production
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,53 @@
+user nginx;
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+
+    upstream backend {
+        server backend:8000;
+    }
+
+    upstream frontend {
+        server frontend:80;
+    }
+
+    server {
+        listen 80;
+
+        location /static/ {
+            alias /var/www/static/;
+            access_log off;
+            expires 30d;
+        }
+
+        location /media/ {
+            alias /var/www/media/;
+            access_log off;
+            expires 30d;
+        }
+
+        location /api/ {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            try_files $uri /index.html;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Dockerfile for backend Python environment
- add Dockerfile for building frontend React app
- create nginx configuration to proxy to backend and serve static/media
- adjust backend static volume path in docker-compose
- add placeholder SSL directory for nginx

## Testing
- `python manage.py migrate`
- `python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: 5 tests failing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684dd8fc06ec8320b1bdb520cb82b384